### PR TITLE
feat[#9]: Move MD5 method to a MarvelCrypto class

### DIFF
--- a/MarvelApp/MarvelApp.xcodeproj/project.pbxproj
+++ b/MarvelApp/MarvelApp.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		FD207BBC27DAB61600A75EA2 /* ImageWithBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BB627DAB61600A75EA2 /* ImageWithBlur.swift */; };
 		FD207BBD27DAB61600A75EA2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BB727DAB61600A75EA2 /* AppDelegate.swift */; };
 		FD207BBE27DAB61600A75EA2 /* TaggingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BB827DAB61600A75EA2 /* TaggingProtocol.swift */; };
+		FD207BC127DAC46E00A75EA2 /* MarvelCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BC027DAC46E00A75EA2 /* MarvelCrypto.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -137,6 +138,7 @@
 		FD207BB627DAB61600A75EA2 /* ImageWithBlur.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageWithBlur.swift; sourceTree = "<group>"; };
 		FD207BB727DAB61600A75EA2 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD207BB827DAB61600A75EA2 /* TaggingProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaggingProtocol.swift; sourceTree = "<group>"; };
+		FD207BC027DAC46E00A75EA2 /* MarvelCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarvelCrypto.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +210,7 @@
 		523765B627469DA200E8BC78 /* MarvelApp */ = {
 			isa = PBXGroup;
 			children = (
+				FD207BBF27DAC44900A75EA2 /* Crypto */,
 				FD207BB227DAB61600A75EA2 /* Utils */,
 				FD207BA527DAB60F00A75EA2 /* Network */,
 				FD207B8E27DAB60800A75EA2 /* Data */,
@@ -406,6 +409,14 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		FD207BBF27DAC44900A75EA2 /* Crypto */ = {
+			isa = PBXGroup;
+			children = (
+				FD207BC027DAC46E00A75EA2 /* MarvelCrypto.swift */,
+			);
+			path = Crypto;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -557,6 +568,7 @@
 				FD207BBC27DAB61600A75EA2 /* ImageWithBlur.swift in Sources */,
 				FD207BA327DAB60800A75EA2 /* Comics.swift in Sources */,
 				527AF10D27907016007247E0 /* DetailsViewModel.swift in Sources */,
+				FD207BC127DAC46E00A75EA2 /* MarvelCrypto.swift in Sources */,
 				522D9E322791B76E00FB6B47 /* HomeViewModelDelegate.swift in Sources */,
 				52E2A2522746BF2100A3AD3E /* DetailsViewController.swift in Sources */,
 				FD207BB027DAB60F00A75EA2 /* HTTPMethod.swift in Sources */,

--- a/MarvelApp/MarvelApp.xcodeproj/project.pbxproj
+++ b/MarvelApp/MarvelApp.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		FD207BBD27DAB61600A75EA2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BB727DAB61600A75EA2 /* AppDelegate.swift */; };
 		FD207BBE27DAB61600A75EA2 /* TaggingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BB827DAB61600A75EA2 /* TaggingProtocol.swift */; };
 		FD207BC127DAC46E00A75EA2 /* MarvelCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BC027DAC46E00A75EA2 /* MarvelCrypto.swift */; };
+		FD207BC527DAC78F00A75EA2 /* MarvelCryptoSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BC427DAC78F00A75EA2 /* MarvelCryptoSpy.swift */; };
+		FD207BC727DAC7B600A75EA2 /* MarvelCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD207BC627DAC7B600A75EA2 /* MarvelCryptoTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,6 +141,8 @@
 		FD207BB727DAB61600A75EA2 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD207BB827DAB61600A75EA2 /* TaggingProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaggingProtocol.swift; sourceTree = "<group>"; };
 		FD207BC027DAC46E00A75EA2 /* MarvelCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarvelCrypto.swift; sourceTree = "<group>"; };
+		FD207BC427DAC78F00A75EA2 /* MarvelCryptoSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarvelCryptoSpy.swift; sourceTree = "<group>"; };
+		FD207BC627DAC7B600A75EA2 /* MarvelCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarvelCryptoTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -333,6 +337,7 @@
 		52B21E682798AFBE00F328AE /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				FD207BC227DAC75C00A75EA2 /* Crypto */,
 				52F41E16275AC25D0074B233 /* HomeViewControllerTests.swift */,
 				526D76F927959C12004184D4 /* HomeViewModelTestes.swift */,
 			);
@@ -415,6 +420,23 @@
 				FD207BC027DAC46E00A75EA2 /* MarvelCrypto.swift */,
 			);
 			path = Crypto;
+			sourceTree = "<group>";
+		};
+		FD207BC227DAC75C00A75EA2 /* Crypto */ = {
+			isa = PBXGroup;
+			children = (
+				FD207BC627DAC7B600A75EA2 /* MarvelCryptoTests.swift */,
+				FD207BC327DAC77B00A75EA2 /* Doubles */,
+			);
+			path = Crypto;
+			sourceTree = "<group>";
+		};
+		FD207BC327DAC77B00A75EA2 /* Doubles */ = {
+			isa = PBXGroup;
+			children = (
+				FD207BC427DAC78F00A75EA2 /* MarvelCryptoSpy.swift */,
+			);
+			path = Doubles;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -600,6 +622,8 @@
 			files = (
 				52EBEB59279612B90005637D /* CoreDataMock.swift in Sources */,
 				526D76FA27959C12004184D4 /* HomeViewModelTestes.swift in Sources */,
+				FD207BC527DAC78F00A75EA2 /* MarvelCryptoSpy.swift in Sources */,
+				FD207BC727DAC7B600A75EA2 /* MarvelCryptoTests.swift in Sources */,
 				52B21E642798AC8300F328AE /* HomeViewControllerSpy.swift in Sources */,
 				52F41E17275AC25D0074B233 /* HomeViewControllerTests.swift in Sources */,
 				52FFA4392756C049006A3F39 /* NetworkServiceSpy.swift in Sources */,

--- a/MarvelApp/MarvelApp.xcodeproj/xcshareddata/xcschemes/MarvelAppTests.xcscheme
+++ b/MarvelApp/MarvelApp.xcodeproj/xcshareddata/xcschemes/MarvelAppTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52FFA42C27566AF1006A3F39"
+               BuildableName = "MarvelAppTests.xctest"
+               BlueprintName = "MarvelAppTests"
+               ReferencedContainer = "container:MarvelApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MarvelApp/MarvelApp/Crypto/MarvelCrypto.swift
+++ b/MarvelApp/MarvelApp/Crypto/MarvelCrypto.swift
@@ -1,0 +1,28 @@
+import CommonCrypto
+import Foundation
+
+protocol MarvelCryptoProtocol {
+    func MD5(string: String) -> String
+}
+
+final class MarvelCrypto: MarvelCryptoProtocol {
+    func MD5(string: String) -> String {
+        let length = Int(CC_MD5_DIGEST_LENGTH)
+        let messageData = string.data(using:.utf8)!
+        var digestData = Data(count: length)
+        
+        _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in
+            messageData.withUnsafeBytes { messageBytes -> UInt8 in
+                if let messageBytesBaseAddress = messageBytes.baseAddress,
+                   let digestBytesBlindMemory = digestBytes.bindMemory(to: UInt8.self).baseAddress
+                {
+                    let messageLength = CC_LONG(messageData.count)
+                    CC_MD5(messageBytesBaseAddress, messageLength, digestBytesBlindMemory)
+                }
+                return 0
+            }
+        }
+        
+        return digestData.map { String(format: "%02hhx", $0) }.joined()
+    }
+}

--- a/MarvelApp/MarvelApp/Network/NetworkService.swift
+++ b/MarvelApp/MarvelApp/Network/NetworkService.swift
@@ -6,13 +6,18 @@
 //
 
 import Foundation
-import var CommonCrypto.CC_MD5_DIGEST_LENGTH
-import func CommonCrypto.CC_MD5
-import typealias CommonCrypto.CC_LONG
 
 class NetworkService: NetworkServiceProtocol {
     
     let baseURL = "http://gateway.marvel.com"
+    
+    // MARK: - Private Properties
+    
+    private let crypto: MarvelCryptoProtocol
+    
+    init(crypto: MarvelCryptoProtocol) {
+        self.crypto = crypto
+    }
     
     func authentication(_ path: String) -> Auth {
         return Auth(path: path,
@@ -25,21 +30,21 @@ class NetworkService: NetworkServiceProtocol {
     func setNewCharacters(_ offset: Int) -> String {
         let auth = authentication("v1/public/characters")
         let content = String(auth.ts) + auth.privateKey + auth.publicKey
-        let hash = MD5(string: content)
+        let hash = crypto.MD5(string: content)
         return baseURL + "/" + auth.path + "?" + "offset=\(offset)" + "&ts=\(auth.ts)" + "&apikey=\(auth.publicKey)" + "&hash=\(hash)"
     }
     
     func searchCharacter(_ nameStartsWith: String) -> String {
         let auth = authentication("v1/public/characters")
         let content = String(auth.ts) + auth.privateKey + auth.publicKey
-        let hash = MD5(string: content)
+        let hash = crypto.MD5(string: content)
         return baseURL + "/" + auth.path + "?" + "nameStartsWith=\(nameStartsWith)" + "&ts=\(auth.ts)" + "&apikey=\(auth.publicKey)" + "&hash=\(hash)"
     }
     
     func setCarouselCharacter(_ serieId: Int) -> String {
         let auth = authentication("v1/public/characters")
         let content = String(auth.ts) + auth.privateKey + auth.publicKey
-        let hash = MD5(string: content)
+        let hash = crypto.MD5(string: content)
         return baseURL + "/" + auth.path + "?" + "series=\(serieId)" + "&ts=\(auth.ts)" + "&apikey=\(auth.publicKey)" + "&hash=\(hash)"
     }
     
@@ -73,23 +78,5 @@ class NetworkService: NetworkServiceProtocol {
             }
         })
         task.resume()
-    }
-    
-    func MD5(string: String) -> String {
-        let length = Int(CC_MD5_DIGEST_LENGTH)
-        let messageData = string.data(using:.utf8)!
-        var digestData = Data(count: length)
-        
-        _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in
-            messageData.withUnsafeBytes { messageBytes -> UInt8 in
-                if let messageBytesBaseAddress = messageBytes.baseAddress, let digestBytesBlindMemory = digestBytes.bindMemory(to: UInt8.self).baseAddress {
-                    let messageLength = CC_LONG(messageData.count)
-                    CC_MD5(messageBytesBaseAddress, messageLength, digestBytesBlindMemory)
-                }
-                return 0
-            }
-        }
-        return digestData.map { String(format: "%02hhx", $0) }.joined()
-    }
-    
+    }    
 }

--- a/MarvelApp/MarvelApp/Network/NetworkServiceProtocol.swift
+++ b/MarvelApp/MarvelApp/Network/NetworkServiceProtocol.swift
@@ -11,5 +11,4 @@ protocol NetworkServiceProtocol {
     func searchCharacter(_ nameStartsWith: String) -> String
     func setCarouselCharacter(_ serieId: Int) -> String
     func getListCharacters(urlString: String, method: HTTPMethod, success: @escaping (Character) -> Void, failure: @escaping (NetworkServiceError) -> Void)
-    func MD5(string: String) -> String
 }

--- a/MarvelApp/MarvelApp/Scene/Home/ViewController/HomeViewController.swift
+++ b/MarvelApp/MarvelApp/Scene/Home/ViewController/HomeViewController.swift
@@ -14,9 +14,13 @@ class HomeViewController: UIViewController {
     
     // MARK: Properties
     let tag: TaggingProtocol
-    var viewModel = HomeViewModel(networkService: NetworkService(),
-                                  coreDataManager: CoreDataManager(),
-                                  parseManager: ParseManager())
+    private let marvelCrypto = MarvelCrypto()
+    
+    lazy var viewModel = HomeViewModel(
+        networkService: NetworkService(crypto: marvelCrypto),
+        coreDataManager: CoreDataManager(),
+        parseManager: ParseManager()
+    )
     
     lazy var emptyStateMessage: UILabel = {
         let messageLabel = UILabel()

--- a/MarvelApp/MarvelAppTests/Tests/Crypto/Doubles/MarvelCryptoSpy.swift
+++ b/MarvelApp/MarvelAppTests/Tests/Crypto/Doubles/MarvelCryptoSpy.swift
@@ -1,0 +1,14 @@
+@testable import MarvelApp
+
+final class MarvelCryptoSpy: MarvelCryptoProtocol {
+    
+    private(set) var MD5Called: Bool = false
+    private(set) var MD5StringPassed: String?
+    var MD5ToBeReturn: String = ""
+    
+    func MD5(string: String) -> String {
+        MD5Called = true
+        MD5StringPassed = string
+        return MD5ToBeReturn
+    }
+}

--- a/MarvelApp/MarvelAppTests/Tests/Crypto/MarvelCryptoTests.swift
+++ b/MarvelApp/MarvelAppTests/Tests/Crypto/MarvelCryptoTests.swift
@@ -1,0 +1,14 @@
+@testable import MarvelApp
+
+import XCTest
+
+final class MarvelCryptoTests: XCTestCase {
+    private let sut = MarvelCrypto()
+
+    func test_MD5_shouldReturnCorrectString() {
+        let expectedResult = sut.MD5(string: "Test")
+        
+        XCTAssertNotEqual(expectedResult, "Test")
+        XCTAssertEqual(expectedResult, "0cbc6611f5540bd0809a388dc95a615b")
+    }
+}


### PR DESCRIPTION
### This PR contains:
[ ] New Feature
[x] Unit Tests
[x] Refactor

### Context and solution:
The NetworkService class was creating the MD5 hash for URLs. This PR moves the MD5 method to a new `MarvelCrypto` class and injected it into the NetworkService class.

### Evidence:
None.